### PR TITLE
remove warning on origin not ending with slash

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,12 +216,6 @@ fn sync_oauth2s(
                 existing_oauth2s.extend(kanidm_client.get_entities(ENDPOINT_OAUTH2)?);
             }
 
-            for origin_url in &origin_urls {
-                if !origin_url.ends_with('/') {
-                    println!("{}", format!("WARN: origin_url ({}) of oauth2 resource server '{name}' should end in a slash! This will lead to unnecessary updates.", origin_url).yellow().bold());
-                }
-            }
-
             if oauth2.public {
                 if oauth2.allow_insecure_client_disable_pkce {
                     println!(

--- a/tests/kanidm.nix
+++ b/tests/kanidm.nix
@@ -464,10 +464,10 @@ in
               };
 
               originUrl = lib.mkOption {
-                description = "The origin URL of the service. OAuth2 redirects will only be allowed to sites under this origin. Must end with a slash.";
+                description = "The origin URL of the service. OAuth2 redirects will only be allowed when exactly matching this value.";
                 type =
                   let
-                    originStrType = lib.types.strMatching ".*://.*/$";
+                    originStrType = lib.types.strMatching ".*://.*$";
                   in
                   lib.types.either originStrType (lib.types.nonEmptyListOf originStrType);
                 example = "https://someservice.example.com/";


### PR DESCRIPTION
Close #12

Adds the strict-redirect-uri setting, and removes the warning when origins do not end in a slash.
