### PR TITLE
feat: Allow declaring memberless groups

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -406,7 +406,7 @@ fn main() -> Result<()> {
     // Sync group members
     log_status("Syncing group members");
     for (name, group) in &state.groups {
-        if group.present {
+        if group.present && !group.memberless {
             update_attrs!(kanidm_client, ENDPOINT_GROUP, &existing_groups, &name, [
                 "member": group.members.clone(),
             ]);

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,8 @@ pub struct Group {
     #[serde(default = "default_true")]
     pub present: bool,
     pub members: Vec<String>,
+    #[serde(default = "default_false")]
+    pub memberless: bool,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
When a group is "memberless", then the list of members is left intact, which allows managing it imperatively.