### PR TITLE
fix: check casing of state keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ KANIDM_RECOVER_ACCOUNT_PASSWORD=V3kACDdwPjYUgYuLdlRfBqeBWf3TyJmv9h0f6CP3E3dv2B4S
 
 ## JSON Schema
 
-This is the schema consumed by this application
+This is the schema consumed by this application.
+
+Note that all keys for `groups`, `persons` and `systems.oauth2` need to be in lowercase.
+E.g. `person1` is allowed, `Person1` or `pErSoN1` are not.
 
 ```yaml
 {

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,7 +60,7 @@ pub struct KanidmClient {
 pub fn get_value_array(attr: &str, existing_entities: &HashMap<String, Value>, name: &str) -> Result<Vec<String>> {
     let entity = existing_entities
         .get(name)
-        .ok_or_else(|| eyre!("Cannot update unknown oauth2 resource server {name}"))?;
+        .ok_or_else(|| eyre!("Cannot update unknown entity {name}"))?;
 
     let current_values = match entity.pointer(attr) {
         Some(Value::Array(x)) => x.iter().filter_map(|x| x.as_str().map(|x| x.to_string())).collect(),


### PR DESCRIPTION
As discussed in https://github.com/oddlama/kanidm-provision/issues/21

tested with the following JSON by changing the keys of the entities to have uppercase letters

```json
{
  "persons": {
    "aoeu": {
      "displayName": "aoeu"
    }
  },
  "groups": {
    "test": { "displayName": "somegroup", "members": ["aoeu"] }
  },
  "systems": {
    "oauth2": {
      "mysystem": {
        "displayName": "aoeu",
        "originUrl": "aoeu",
        "originLanding": "aoeu"
      }
    }
  }
}
```