### PR TITLE
feat: Allow provisioning a groups entry_managed_by attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ PRs are of course welcome!
 | ✅ | Create/delete
 | ✅ | Members
 | ✅ | Unix attributes
+| ✅ | Attributes (entry_managed_by)
 | |
 | 🧑 | **Persons**
 | ✅ | Create/delete
@@ -135,7 +136,8 @@ E.g. `person1` is allowed, `Person1` or `pErSoN1` are not.
       # Optional. Defaults to false if not given.
       "enableUnix": true,
       # Optional.
-      "gidNumber": 1234
+      "gidNumber": 1234,
+      "entryManagedBy": "Per Son",
     },
     # ...
   },

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,10 @@ fn sync_groups(
                 existing_groups.clear();
                 existing_groups.extend(kanidm_client.get_entities(ENDPOINT_GROUP)?);
             }
+
+            update_attrs!(kanidm_client, ENDPOINT_GROUP, &existing_groups, &name, false, [
+                "entry_managed_by": group.entry_managed_by.clone().map_or_else(Vec::new, |x| vec![x]),
+            ]);
         } else if existing_groups.contains_key(name) {
             kanidm_client.delete_entity(ENDPOINT_GROUP, name)?;
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -15,6 +15,7 @@ pub struct Group {
     #[serde(default = "default_false")]
     pub enable_unix: bool,
     pub gid_number: Option<u32>,
+    pub entry_managed_by: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
When a group requires elevated privileges, it needs to be managed by a group with elevated privileges. An example is described [here](https://github.com/kanidm/kanidm/discussions/4484).

This commit adds the ability to set this attribute for groups, analogue to the `kanidm group set-entry-manager` functionality of the kanidm client cli.